### PR TITLE
Managed Redux State for Filters

### DIFF
--- a/client/src/app/api/agent.ts
+++ b/client/src/app/api/agent.ts
@@ -56,7 +56,8 @@ const requests = {
 // Another object that is going to store requests for the catalog.
 const Catalog = {
     list: () => requests.get("products"),
-    details: (id: number) => requests.get(`products/${id}`)
+    details: (id: number) => requests.get(`products/${id}`),
+    fetchFilters: () => requests.get("products/filters")
 }
 
 // Error Routes

--- a/client/src/features/catalog/Catalog.tsx
+++ b/client/src/features/catalog/Catalog.tsx
@@ -2,20 +2,28 @@ import LoadingComponent from "../../app/layout/LoadingComponents";
 import { useAppDispatch, useAppSelector } from "../../app/store/configureStore";
 import ProductList from "./ProductList";
 import { useEffect } from "react";
-import { fetchProductsAsync, productSelectors } from "./catalogSlice";
+import { fetchFilters, fetchProductsAsync, productSelectors } from "./catalogSlice";
 
 
 
 export default function Catalog() {
 
     const products = useAppSelector(productSelectors.selectAll);
-    const {productsLoaded, status} = useAppSelector(state => state.catalog);
+    const {productsLoaded, status, filtersLoaded} = useAppSelector(state => state.catalog);
     const dispatch = useAppDispatch();
 
     // using Axios from agent.
     useEffect(() => {
         if (!productsLoaded) dispatch(fetchProductsAsync());
     }, [productsLoaded, dispatch])
+
+    // another useEffect to avoid getting the products Twice from
+    // from the API. If fetchFilters was in the above useEffect,
+    // It would retrieve the products from the API, then fetch-
+    // Filters, THEN retrieve the Products from the API once again.
+    useEffect(() => {
+        if (!filtersLoaded) dispatch(fetchFilters());
+    }, [filtersLoaded, dispatch])
 
     if (status.includes("pending")) return <LoadingComponent message="Loading Games..."/>
 

--- a/client/src/features/catalog/catalogSlice.ts
+++ b/client/src/features/catalog/catalogSlice.ts
@@ -27,11 +27,25 @@ export const fetchProductAsync = createAsyncThunk<Product, number>(
     }
 )
 
+export const fetchFilters = createAsyncThunk(
+    "catalog/fetchFilters",
+    async (_, thunkApi) => {
+        try {
+            return agent.Catalog.fetchFilters();
+        } catch (error: any) {
+            return thunkApi.rejectWithValue({error: error.data});
+        }
+    }
+)
+
 export const catalogSlice = createSlice({
     name: "catalog",
     initialState: productsAdapter.getInitialState({
         productsLoaded: false,
-        status: "idle"
+        filtersLoaded: false,
+        status: "idle",
+        brands: [],
+        types: []
     }),
     reducers: {},
     extraReducers: (builder => {
@@ -61,6 +75,19 @@ export const catalogSlice = createSlice({
             console.log(action)
             state.status = "idle";
         });
+        builder.addCase(fetchFilters.pending, (state) => {
+            state.status = "pendingFetchFilters";
+        });
+        builder.addCase(fetchFilters.fulfilled, (state, action) => {
+            state.brands = action.payload.brands;
+            state.types = action.payload.types;
+            state.filtersLoaded = true;
+            state.status = "idle";
+        });
+        builder.addCase(fetchFilters.rejected, (state, action) => {
+            state.status = "idle";
+            console.log(action.payload);
+        })
     })
 })
 


### PR DESCRIPTION
Close #72 

Managed filters to be fetched and put into the Redux state in order for the brands and types to be fetched from the API. 

Prevented a performance issue caused where the fetchFilters is in the same useEffect as the productsLoaded (fetchProductsAsync (fetching the products from the API)). After fetching the products from the API, the fetchFilters() would trigger, fetching the filters from the API, then filtersLoaded would then be set to true, causing the useEffect to fetch the products from the API once again. That would cause -> fetch products -> fetch filters -> fetch products 'AGAIN'.

Putting fetchFilters in its OWN useEffect allows for only one call to the API to fetch the products. fetch products -> fetch filters -> DONE.