### PR TITLE
Sent up params to url request via query string

### DIFF
--- a/client/src/app/api/agent.ts
+++ b/client/src/app/api/agent.ts
@@ -47,7 +47,9 @@ axios.interceptors.response.use(async response => {
 
 // Add an object for different types of requests.
 const requests = {
-    get: (url: string) => axios.get(url).then(responseBody),
+    // Added URLSearchParams (interface) here to allow to pass up the params to the request.
+    // axios.get can be passed up as a type of object, here it will be of type: URLSearchParams. 
+    get: (url: string, params?: URLSearchParams) => axios.get(url, {params}).then(responseBody),
     post: (url: string, body: object) => axios.post(url, body).then(responseBody),
     put: (url: string, body: object) => axios.put(url, body).then(responseBody),
     delete: (url: string) => axios.delete(url).then(responseBody)
@@ -55,7 +57,7 @@ const requests = {
 
 // Another object that is going to store requests for the catalog.
 const Catalog = {
-    list: () => requests.get("products"),
+    list: (params: URLSearchParams) => requests.get("products", params),
     details: (id: number) => requests.get(`products/${id}`),
     fetchFilters: () => requests.get("products/filters")
 }

--- a/client/src/app/models/product.ts
+++ b/client/src/app/models/product.ts
@@ -10,3 +10,14 @@ export interface Product {
     // quantity in stock can be optional in case default obj is null.
     quantityInStock?: number
 }
+
+// Stores the product parameters.
+export interface ProductParams {
+    orderBy: string;
+    // following 3 are optional because the filters don't need to be sent up
+    searchTerm?: string;
+    types?: string[];
+    brands?: string[];
+    pageNumber: number;
+    pageSize: number;
+}

--- a/client/src/features/catalog/catalogSlice.ts
+++ b/client/src/features/catalog/catalogSlice.ts
@@ -1,15 +1,37 @@
 import { createAsyncThunk, createEntityAdapter, createSlice } from "@reduxjs/toolkit";
-import { Product } from "../../app/models/product";
+import { Product, ProductParams } from "../../app/models/product";
 import agent from "../../app/api/agent";
 import { RootState } from "../../app/store/configureStore";
 
+// Sending these up to the API as a Query String.
+interface CatalogState {
+    productsLoaded: boolean;
+    filtersLoaded: boolean;
+    status: string;
+    brands: string[];
+    types: string[];
+    productParams: ProductParams;
+}
+
 const productsAdapter = createEntityAdapter<Product>();
 
-export const fetchProductsAsync = createAsyncThunk<Product[]>(
+function getAxiosParams(productParams: ProductParams) {
+    const params = new URLSearchParams();
+    params.append("pageNumber", productParams.pageNumber.toString());
+    params.append("pageSize", productParams.pageSize.toString());
+    params.append("orderBy", productParams.orderBy.toString());
+    if (productParams.searchTerm) params.append("searchTerm", productParams.searchTerm);
+    if (productParams.brands) params.append("brands", productParams.brands.toString());
+    if (productParams.types) params.append("types", productParams.types.toString());
+    return params;
+}
+
+export const fetchProductsAsync = createAsyncThunk<Product[], void, {state: RootState}>(
     "catalog/fetchProductsAsync",
     async (_, thunkAPI) => {
+        const params = getAxiosParams(thunkAPI.getState().catalog.productParams);
         try {
-            return await agent.Catalog.list();
+            return await agent.Catalog.list(params);
         } catch (error: any) {
             return thunkAPI.rejectWithValue({error: error.data})
         }
@@ -38,16 +60,36 @@ export const fetchFilters = createAsyncThunk(
     }
 )
 
+// Helper Function.
+function initParams() {
+    return {
+        pageNumber: 1,
+        pageSize: 6,
+        orderBy: "name"
+    }
+}
+
 export const catalogSlice = createSlice({
     name: "catalog",
-    initialState: productsAdapter.getInitialState({
+    initialState: productsAdapter.getInitialState<CatalogState>({
         productsLoaded: false,
         filtersLoaded: false,
         status: "idle",
         brands: [],
-        types: []
+        types: [],
+        // sends up the paramters to the API so it can
+        // give the correct information back to the client.
+        productParams: initParams()
     }),
-    reducers: {},
+    reducers: {
+        setProductParams: (state, action) => {
+            state.productsLoaded = false;
+            state.productParams = {...state.productParams, ...action.payload};
+        },
+        resetProductParams: (state) => {
+            state.productParams = initParams();
+        }
+    },
     extraReducers: (builder => {
         // Products From Catalog!
         builder.addCase(fetchProductsAsync.pending, (state) => {
@@ -92,3 +134,5 @@ export const catalogSlice = createSlice({
 })
 
 export const productSelectors = productsAdapter.getSelectors((state: RootState) => state.catalog);
+
+export const {setProductParams, resetProductParams} = catalogSlice.actions;


### PR DESCRIPTION
Close #77 

Made some adjustments to be able to send the params up to the API as a query string so when the sort, filter, and search are being used, the request reflects in the get request and URL.